### PR TITLE
Fix typo in thunderbird version variable

### DIFF
--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -15,7 +15,7 @@ else
 			sleep infinity
 		fi
 	else
-		LAT_V="$TUNDERBIRD_V"
+		LAT_V="$THUNDERBIRD_V"
 	fi
 fi
 


### PR DESCRIPTION
Found and fixed a typo in the thunderbird version file which prevented initial starting of the container for me.

I had set the variables based on documentation but it could not download the initial version of thunderbird as the version variable was empty